### PR TITLE
Append NDReader scripts & updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,29 @@ The csv files contain the following columns:
 - Date: The date and time when the data was collected (e.g., 29/03/2024 13:46:44)
 
 ### dynamic_tools
+The directory `NDRunners` contains Python scripts that allow for easy management of extracting GitHub Action logs and nondeterminism analysis. This nondeterminism analysis functions based on the `difflib` library in Python. `difflib` is a python builtin library that computes deltas (in other words, file comparisons). File comparisons are made based on the same operating system the tools were run in across the 10 different branches made in each one. To run any of these tools, you must make sure you first have the AbstractReader.py class and then the desired Runner script. Here is an example for one of the dynamic analysis tools: 
+
+*Note that you'll need to make sure you have enough API requests to be able to run all projects (if desired). You can check how many API requests you've made by calling the following command -->* `curl -H "Authorization: token <APItoken> " https://api.github.com/rate_limit`
+
+
+```
+if __name__ == '__main__':
+  repo_usr = "<-- insert repository owner/organization -->"
+  repos = [<-- list all repositories that contain "Run JPF" -->]
+  output_dir = "<--insert the directory you want to store all runner logs-->"
+  token = "<-- this can be a organization GitHub API token or a personal access token (choose classic)-->"
+
+  for repo in repos:
+    jpf = JPFReader(repo_usr, repo, output_dir, token)
+    repo_nd_results = jpf.nondeterminism_analysis() // allows for manual dynamic analysis if needed
+```
+
+Supported Dynamic Analysis Tools (at the moment): 
+1. JavaPathFinder (JPF)
+2. CASR
+3. VMware Chap
+4. Klee
+5. Google AddressSanitizer (also Google LeakSanitizer in certain projects)
+6. Google MemorySanitizer
+7. Google ThreadSanitizer
+8. Valgrind

--- a/scripts/NDReaders/AbstractReaders.py
+++ b/scripts/NDReaders/AbstractReaders.py
@@ -79,7 +79,7 @@ class AbstractReader(ABC):
                         print(f"Invalid location! File {log_filename} not found.")
 
     def download_artifacts(self, repo_owner, repo_name, output_dir,  workflow_name, pat_token):
-        excluded_branches = ['main', 'master', '1.8', '3.2', '4.1', '2.x', '2023.x', '3.x', 'dev', 'devel', 'develop', 'release-v2', 'trunk', 'uinverse', 'v5-master', 'next', 'v1.x']
+        excluded_branches = ['main', 'master', '1.8', '3.2', '4.1', '2.x', '2023.x', '3.x', 'dev', 'devel', 'develop', 'release-v2', 'trunk', 'uinverse', 'v5-master', 'next', 'v1.x', 'unstable']
         headers = {
             "Accept": "application/vnd.github.v3+json",
             "Authorization": f"Bearer {pat_token}"

--- a/scripts/NDReaders/AbstractReaders.py
+++ b/scripts/NDReaders/AbstractReaders.py
@@ -1,0 +1,125 @@
+#  Nondeterminism Dynamic Analysis Python Abstract Class
+#
+#  Copyright (c) 2024.
+#
+#  This program is free software: you can redistribute it and/or modify
+#      it under the terms of the GNU General Public License as published by
+#      the Free Software Foundation, either version 3 of the License, or
+#      (at your option) any later version.
+#
+#      This program is distributed in the hope that it will be useful,
+#      but WITHOUT ANY WARRANTY; without even the implied warranty of
+#      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#      GNU General Public License for more details.
+#
+#      You should have received a copy of the GNU General Public License
+#      along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from abc import ABC, abstractmethod
+from typing import TypeVar, Iterable
+import os
+import requests
+import re 
+
+T = TypeVar('T')
+
+class AbstractReader(ABC):
+    def import_file(self, output_dir, repo_name, action_name, start_phrase, apitoken):
+        output_dir = os.path.expanduser(output_dir)
+        repo_folder = os.path.join(output_dir, repo_name)
+        os.makedirs(repo_folder, exist_ok=True)
+
+        self.download_artifacts(self.repo_user, self.repo_name, repo_folder, action_name, apitoken)
+        
+        for job_folder in os.listdir(repo_folder):
+            job_folder_path = os.path.join(repo_folder, job_folder)
+
+            if not os.path.isdir(job_folder_path):
+                continue
+
+            for filename in os.listdir(job_folder_path):
+                if filename.endswith(".txt"): 
+                    log_filename = os.path.join(job_folder_path, filename)
+
+                    try:
+                        with open(log_filename, 'r') as file:
+                            lines = file.readlines()
+
+                        iso_pattern = r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?'
+                        def remove_timestamp(line):
+                            return re.sub(iso_pattern, '', line).lstrip()
+
+                        modified_lines = [remove_timestamp(line) for line in lines]
+
+                        with open(log_filename, 'w') as f:
+                            f.writelines(modified_lines)
+
+                        start_pattern = rf"{start_phrase}.*"
+                        end_pattern = r"Post job cleanup\."
+
+                        with open(log_filename, 'r') as file:
+                            input_text = file.read()
+
+                        start_match = re.search(start_pattern, input_text)
+                        end_match = re.search(end_pattern, input_text)
+
+                        if start_match and end_match:
+                            start_index = start_match.start()
+                            end_index = end_match.start()
+
+                            extracted_text = input_text[start_index:end_index]
+
+                            with open(log_filename, 'w') as file: 
+                                file.write(extracted_text.strip())
+                        else:
+                            print("Failed to cleanup log! Skipping....")
+                            continue
+                                                
+                    except FileNotFoundError:
+                        print(f"Invalid location! File {log_filename} not found.")
+
+    def download_artifacts(self, repo_owner, repo_name, output_dir,  workflow_name, pat_token):
+        excluded_branches = ['main', 'master', '1.8', '3.2', '4.1', '2.x', '2023.x', '3.x', 'dev', 'devel', 'develop', 'release-v2', 'trunk', 'uinverse', 'v5-master', 'next', 'v1.x']
+        headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": f"Bearer {pat_token}"
+        }
+
+        branches_response = requests.get(
+            f"https://api.github.com/repos/{repo_owner}/{repo_name}/branches",
+            headers=headers
+        )
+        branches_response.raise_for_status()
+        branches = [branch['name'] for branch in branches_response.json() if branch['name'] not in excluded_branches]
+
+        for branch in branches:
+            runs_response = requests.get(
+                f"https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs",
+                params={"branch": branch},
+                headers=headers
+            )
+            runs_response.raise_for_status()
+            runs = runs_response.json()['workflow_runs']
+            filtered_runs = [run for run in runs if run['name'] == workflow_name]
+
+            for run in filtered_runs:
+                jobs_response = requests.get(
+                    f"https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs/{run['id']}/jobs",
+                    headers=headers
+                )
+                jobs_response.raise_for_status()
+                jobs = jobs_response.json()['jobs']
+
+                for job in jobs:
+                    job_folder = os.path.join(output_dir, f"job_{job['name']}")
+                    os.makedirs(job_folder, exist_ok=True) 
+
+                    job_logs_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/actions/jobs/{job['id']}/logs"
+                    job_logs_filename = os.path.join(job_folder, f"{branch}.txt")
+                    response = requests.get(
+                        job_logs_url,
+                        headers=headers
+                    )
+                    response.raise_for_status()
+                    with open(job_logs_filename, 'wb') as f:
+                        f.write(response.content)

--- a/scripts/NDReaders/AsanRunner.py
+++ b/scripts/NDReaders/AsanRunner.py
@@ -1,0 +1,71 @@
+from AbstractReader import AbstractReader, T
+import os 
+import difflib
+
+class AsanRunner(AbstractReader):
+    def __init__(self, repo_user, repo_name, output_dir, token):
+        self.output_dir = output_dir
+        self.repo_user = repo_user
+        self.repo_name = repo_name
+        self.results = {}
+        self.token = token 
+        self.import_file(self.output_dir, self.repo_name, "Run AddressSanitizer", "Run #!/bin/bash", self.token)
+    
+    def nondeterminism_analysis(self): 
+        output_dir = os.path.expanduser(self.output_dir)
+        repo_folder = os.path.join(output_dir, self.repo_name)
+        nondeterminism = False
+        all_nd_results = []
+
+        try:
+            os.makedirs(repo_folder, exist_ok=True)
+            # Iterate through all job folders in repo_folder
+            for job_folder in os.listdir(repo_folder):
+                job_folder_path = os.path.join(repo_folder, job_folder)
+
+                # Skip non-directory entries
+                if not os.path.isdir(job_folder_path):
+                    continue
+                
+                file_names = sorted(os.listdir(job_folder_path))
+                for i in range(len(file_names) - 1):
+                    file_path1 = os.path.join(job_folder_path, file_names[i])
+                    file_path2 = os.path.join(job_folder_path, file_names[i + 1])
+
+                    if os.path.isfile(file_path1) and os.path.isfile(file_path2):
+                        differences = []
+                        with open(file_path1, 'r', encoding='utf-8') as file1, open(file_path2, 'r', encoding='utf-8') as file2:
+                            lines1 = file1.readlines()
+                            lines2 = file2.readlines()
+
+                            differ = difflib.Differ()
+                            diff = list(differ.compare(lines1, lines2))
+
+                            for j, line in enumerate(diff):
+                                # Check for differences (lines starting with '-' or '+')
+                                if line.startswith('-'):
+                                    differences.append(f"File #1: {os.path.basename(file_path1).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+                                elif line.startswith('+'):
+                                    differences.append(f"File #2: {os.path.basename(file_path2).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+
+                        if differences:
+                            nondeterminism = True
+                            print("Found nondeterminism! (check below for the differences found)")
+                            print(f"Filename #1: {file_path1} <-------> Filename #2: {file_path2}")
+                            for diff in differences:
+                                print(diff)
+                            print("\n\n\n")
+
+                            all_nd_results.append(differences)
+                    
+        except OSError as e:
+            print(f"Error creating or accessing directory {repo_folder}: {e}")
+        
+        except Exception as e:
+            print(f"Error: {e}")
+
+        if (not nondeterminism):
+            print("No nondeterminism detected!")
+            return "None reported"
+        else:
+            return all_nd_results

--- a/scripts/NDReaders/CASRReader.py
+++ b/scripts/NDReaders/CASRReader.py
@@ -1,0 +1,71 @@
+from AbstractReader import AbstractReader, T
+import os 
+import difflib
+
+class CASRReader(AbstractReader):
+    def __init__(self, repo_user, repo_name, output_dir, token):
+        self.output_dir = output_dir
+        self.repo_user = repo_user
+        self.repo_name = repo_name
+        self.results = {}
+        self.token = token 
+        self.import_file(self.output_dir, self.repo_name, "Run CASR", "Error: Program terminated", self.token)
+    
+    def nondeterminism_analysis(self): 
+        output_dir = os.path.expanduser(self.output_dir)
+        repo_folder = os.path.join(output_dir, self.repo_name)
+        nondeterminism = False
+        all_nd_results = []
+
+        try:
+            os.makedirs(repo_folder, exist_ok=True)
+            # Iterate through all job folders in repo_folder
+            for job_folder in os.listdir(repo_folder):
+                job_folder_path = os.path.join(repo_folder, job_folder)
+
+                # Skip non-directory entries
+                if not os.path.isdir(job_folder_path):
+                    continue
+                
+                file_names = sorted(os.listdir(job_folder_path))
+                for i in range(len(file_names) - 1):
+                    file_path1 = os.path.join(job_folder_path, file_names[i])
+                    file_path2 = os.path.join(job_folder_path, file_names[i + 1])
+
+                    if os.path.isfile(file_path1) and os.path.isfile(file_path2):
+                        differences = []
+                        with open(file_path1, 'r', encoding='utf-8') as file1, open(file_path2, 'r', encoding='utf-8') as file2:
+                            lines1 = file1.readlines()
+                            lines2 = file2.readlines()
+
+                            differ = difflib.Differ()
+                            diff = list(differ.compare(lines1, lines2))
+
+                            for j, line in enumerate(diff):
+                                # Check for differences (lines starting with '-' or '+')
+                                if line.startswith('-'):
+                                    differences.append(f"File #1: {os.path.basename(file_path1).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+                                elif line.startswith('+'):
+                                    differences.append(f"File #2: {os.path.basename(file_path2).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+
+                        if differences:
+                            nondeterminism = True
+                            print("Found nondeterminism! (check below for the differences found)")
+                            print(f"Filename #1: {file_path1} <-------> Filename #2: {file_path2}")
+                            for diff in differences:
+                                print(diff)
+                            print("\n\n\n")
+
+                            all_nd_results.append(differences)
+                    
+        except OSError as e:
+            print(f"Error creating or accessing directory {repo_folder}: {e}")
+        
+        except Exception as e:
+            print(f"Error: {e}")
+
+        if (not nondeterminism):
+            print("No nondeterminism detected!")
+            return "None reported"
+        else:
+            return all_nd_results

--- a/scripts/NDReaders/ChapReader.py
+++ b/scripts/NDReaders/ChapReader.py
@@ -1,0 +1,71 @@
+from AbstractReader import AbstractReader, T
+import os 
+import difflib
+
+class ChapReader(AbstractReader):
+    def __init__(self, repo_user, repo_name, output_dir, token):
+        self.output_dir = output_dir
+        self.repo_user = repo_user
+        self.repo_name = repo_name
+        self.results = {}
+        self.token = token 
+        self.import_file(self.output_dir, self.repo_name, "Run VMware Chap", "Segmentation fault", self.token)
+    
+    def nondeterminism_analysis(self): 
+        output_dir = os.path.expanduser(self.output_dir)
+        repo_folder = os.path.join(output_dir, self.repo_name)
+        nondeterminism = False
+        all_nd_results = []
+
+        try:
+            os.makedirs(repo_folder, exist_ok=True)
+            # Iterate through all job folders in repo_folder
+            for job_folder in os.listdir(repo_folder):
+                job_folder_path = os.path.join(repo_folder, job_folder)
+
+                # Skip non-directory entries
+                if not os.path.isdir(job_folder_path):
+                    continue
+                
+                file_names = sorted(os.listdir(job_folder_path))
+                for i in range(len(file_names) - 1):
+                    file_path1 = os.path.join(job_folder_path, file_names[i])
+                    file_path2 = os.path.join(job_folder_path, file_names[i + 1])
+
+                    if os.path.isfile(file_path1) and os.path.isfile(file_path2):
+                        differences = []
+                        with open(file_path1, 'r', encoding='utf-8') as file1, open(file_path2, 'r', encoding='utf-8') as file2:
+                            lines1 = file1.readlines()
+                            lines2 = file2.readlines()
+
+                            differ = difflib.Differ()
+                            diff = list(differ.compare(lines1, lines2))
+
+                            for j, line in enumerate(diff):
+                                # Check for differences (lines starting with '-' or '+')
+                                if line.startswith('-'):
+                                    differences.append(f"File #1: {os.path.basename(file_path1).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+                                elif line.startswith('+'):
+                                    differences.append(f"File #2: {os.path.basename(file_path2).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+
+                        if differences:
+                            nondeterminism = True
+                            print("Found nondeterminism! (check below for the differences found)")
+                            print(f"Filename #1: {file_path1} <-------> Filename #2: {file_path2}")
+                            for diff in differences:
+                                print(diff)
+                            print("\n\n\n")
+
+                            all_nd_results.append(differences)
+                    
+        except OSError as e:
+            print(f"Error creating or accessing directory {repo_folder}: {e}")
+        
+        except Exception as e:
+            print(f"Error: {e}")
+
+        if (not nondeterminism):
+            print("No nondeterminism detected!")
+            return "None reported"
+        else:
+            return all_nd_results

--- a/scripts/NDReaders/JPFReader.py
+++ b/scripts/NDReaders/JPFReader.py
@@ -1,0 +1,94 @@
+#  Nondeterminism Dynamic Analysis Python JPFReader Class
+#
+#  Copyright (c) 2024.
+#
+#  This program is free software: you can redistribute it and/or modify
+#      it under the terms of the GNU General Public License as published by
+#      the Free Software Foundation, either version 3 of the License, or
+#      (at your option) any later version.
+#
+#      This program is distributed in the hope that it will be useful,
+#      but WITHOUT ANY WARRANTY; without even the implied warranty of
+#      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#      GNU General Public License for more details.
+#
+#      You should have received a copy of the GNU General Public License
+#      along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from AbstractReader import AbstractReader, T
+import os 
+import difflib
+
+class JavaPathFinder(AbstractReader):
+    def __init__(self, repo_user, repo_name, output_dir, token):
+        self.output_dir = output_dir
+        self.repo_user = repo_user
+        self.repo_name = repo_name
+        self.results = {}
+        self.token = token
+        self.import_file(self.output_dir, self.repo_name, "Run JPF", "JavaPathfinder core system", self.token)
+
+    def nondeterminism_analysis(self):
+        output_dir = os.path.expanduser(self.output_dir)
+        repo_folder = os.path.join(output_dir, self.repo_name)
+        nondeterminism = False
+        all_nd_results = []
+
+        try:
+            os.makedirs(repo_folder, exist_ok=True)
+
+            # Iterate through all job folders in repo_folder
+            for job_folder in os.listdir(repo_folder):
+                job_folder_path = os.path.join(repo_folder, job_folder)
+
+                # Skip non-directory entries
+                if not os.path.isdir(job_folder_path):
+                    continue
+                
+                file_names = sorted(os.listdir(job_folder_path))
+                for i in range(len(file_names) - 1):
+                    file_path1 = os.path.join(job_folder_path, file_names[i])
+                    file_path2 = os.path.join(job_folder_path, file_names[i + 1])
+
+                    if os.path.isfile(file_path1) and os.path.isfile(file_path2):
+                        differences = []
+                        with open(file_path1, 'r', encoding='utf-8') as file1, open(file_path2, 'r', encoding='utf-8') as file2:
+                            lines1 = file1.readlines()
+                            lines2 = file2.readlines()
+
+                            differ = difflib.Differ()
+                            diff = list(differ.compare(lines1, lines2))
+
+                            for j, line in enumerate(diff):
+                                # Check if the line contains "search started:" or "search finished"
+                                if ' search started:' in line or ' search finished' in line:
+                                    continue  # Skip this line
+
+                                # Check for differences (lines starting with '-' or '+')
+                                if line.startswith('-'):
+                                    differences.append(f"File #1: {os.path.basename(file_path1).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+                                elif line.startswith('+'):
+                                    differences.append(f"File #2: {os.path.basename(file_path2).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+
+                        if differences:
+                            nondeterminism = True
+                            print("Found nondeterminism! (check below for the differences found)")
+                            print(f"Filename #1: {file_path1} <-------> Filename #2: {file_path2}")
+                            for diff in differences:
+                                print(diff)
+                            print("\n\n\n")
+
+                            all_nd_results.append(differences)
+                    
+        except OSError as e:
+            print(f"Error creating or accessing directory {repo_folder}: {e}")
+        
+        except Exception as e:
+            print(f"Error: {e}")
+
+        if (not nondeterminism):
+            print("No nondeterminism detected!")
+            return "None reported"
+        else:
+            return all_nd_results

--- a/scripts/NDReaders/KleeRunner.py
+++ b/scripts/NDReaders/KleeRunner.py
@@ -1,0 +1,71 @@
+from AbstractReader import AbstractReader, T
+import os 
+import difflib
+
+class KleeRunner(AbstractReader):
+    def __init__(self, repo_user, repo_name, output_dir, token):
+        self.output_dir = output_dir
+        self.repo_user = repo_user
+        self.repo_name = repo_name
+        self.results = {}
+        self.token = token 
+        self.import_file(self.output_dir, self.repo_name, "Run Klee", "KLEE: output directory ", self.token)
+    
+    def nondeterminism_analysis(self): 
+        output_dir = os.path.expanduser(self.output_dir)
+        repo_folder = os.path.join(output_dir, self.repo_name)
+        nondeterminism = False
+        all_nd_results = []
+
+        try:
+            os.makedirs(repo_folder, exist_ok=True)
+            # Iterate through all job folders in repo_folder
+            for job_folder in os.listdir(repo_folder):
+                job_folder_path = os.path.join(repo_folder, job_folder)
+
+                # Skip non-directory entries
+                if not os.path.isdir(job_folder_path):
+                    continue
+                
+                file_names = sorted(os.listdir(job_folder_path))
+                for i in range(len(file_names) - 1):
+                    file_path1 = os.path.join(job_folder_path, file_names[i])
+                    file_path2 = os.path.join(job_folder_path, file_names[i + 1])
+
+                    if os.path.isfile(file_path1) and os.path.isfile(file_path2):
+                        differences = []
+                        with open(file_path1, 'r', encoding='utf-8') as file1, open(file_path2, 'r', encoding='utf-8') as file2:
+                            lines1 = file1.readlines()
+                            lines2 = file2.readlines()
+
+                            differ = difflib.Differ()
+                            diff = list(differ.compare(lines1, lines2))
+
+                            for j, line in enumerate(diff):
+                                # Check for differences (lines starting with '-' or '+')
+                                if line.startswith('-'):
+                                    differences.append(f"File #1: {os.path.basename(file_path1).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+                                elif line.startswith('+'):
+                                    differences.append(f"File #2: {os.path.basename(file_path2).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+
+                        if differences:
+                            nondeterminism = True
+                            print("Found nondeterminism! (check below for the differences found)")
+                            print(f"Filename #1: {file_path1} <-------> Filename #2: {file_path2}")
+                            for diff in differences:
+                                print(diff)
+                            print("\n\n\n")
+
+                            all_nd_results.append(differences)
+                    
+        except OSError as e:
+            print(f"Error creating or accessing directory {repo_folder}: {e}")
+        
+        except Exception as e:
+            print(f"Error: {e}")
+
+        if (not nondeterminism):
+            print("No nondeterminism detected!")
+            return "None reported"
+        else:
+            return all_nd_results

--- a/scripts/NDReaders/MsanReader.py
+++ b/scripts/NDReaders/MsanReader.py
@@ -1,0 +1,71 @@
+from AbstractReader import AbstractReader, T
+import os 
+import difflib
+
+class MsanRunner(AbstractReader):
+    def __init__(self, repo_user, repo_name, output_dir, token):
+        self.output_dir = output_dir
+        self.repo_user = repo_user
+        self.repo_name = repo_name
+        self.results = {}
+        self.token = token 
+        self.import_file(self.output_dir, self.repo_name, "Run MemorySanitizer", "Run #!/bin/bash", self.token)
+    
+    def nondeterminism_analysis(self): 
+        output_dir = os.path.expanduser(self.output_dir)
+        repo_folder = os.path.join(output_dir, self.repo_name)
+        nondeterminism = False
+        all_nd_results = []
+
+        try:
+            os.makedirs(repo_folder, exist_ok=True)
+            # Iterate through all job folders in repo_folder
+            for job_folder in os.listdir(repo_folder):
+                job_folder_path = os.path.join(repo_folder, job_folder)
+
+                # Skip non-directory entries
+                if not os.path.isdir(job_folder_path):
+                    continue
+                
+                file_names = sorted(os.listdir(job_folder_path))
+                for i in range(len(file_names) - 1):
+                    file_path1 = os.path.join(job_folder_path, file_names[i])
+                    file_path2 = os.path.join(job_folder_path, file_names[i + 1])
+
+                    if os.path.isfile(file_path1) and os.path.isfile(file_path2):
+                        differences = []
+                        with open(file_path1, 'r', encoding='utf-8') as file1, open(file_path2, 'r', encoding='utf-8') as file2:
+                            lines1 = file1.readlines()
+                            lines2 = file2.readlines()
+
+                            differ = difflib.Differ()
+                            diff = list(differ.compare(lines1, lines2))
+
+                            for j, line in enumerate(diff):
+                                # Check for differences (lines starting with '-' or '+')
+                                if line.startswith('-'):
+                                    differences.append(f"File #1: {os.path.basename(file_path1).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+                                elif line.startswith('+'):
+                                    differences.append(f"File #2: {os.path.basename(file_path2).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+
+                        if differences:
+                            nondeterminism = True
+                            print("Found nondeterminism! (check below for the differences found)")
+                            print(f"Filename #1: {file_path1} <-------> Filename #2: {file_path2}")
+                            for diff in differences:
+                                print(diff)
+                            print("\n\n\n")
+
+                            all_nd_results.append(differences)
+                    
+        except OSError as e:
+            print(f"Error creating or accessing directory {repo_folder}: {e}")
+        
+        except Exception as e:
+            print(f"Error: {e}")
+
+        if (not nondeterminism):
+            print("No nondeterminism detected!")
+            return "None reported"
+        else:
+            return all_nd_results

--- a/scripts/NDReaders/TsanReader.py
+++ b/scripts/NDReaders/TsanReader.py
@@ -1,0 +1,71 @@
+from AbstractReader import AbstractReader, T
+import os 
+import difflib
+
+class TsanRunner(AbstractReader):
+    def __init__(self, repo_user, repo_name, output_dir, token):
+        self.output_dir = output_dir
+        self.repo_user = repo_user
+        self.repo_name = repo_name
+        self.results = {}
+        self.token = token 
+        self.import_file(self.output_dir, self.repo_name, "Run ThreadSanitizer", "Run #!/bin/bash", self.token)
+    
+    def nondeterminism_analysis(self): 
+        output_dir = os.path.expanduser(self.output_dir)
+        repo_folder = os.path.join(output_dir, self.repo_name)
+        nondeterminism = False
+        all_nd_results = []
+
+        try:
+            os.makedirs(repo_folder, exist_ok=True)
+            # Iterate through all job folders in repo_folder
+            for job_folder in os.listdir(repo_folder):
+                job_folder_path = os.path.join(repo_folder, job_folder)
+
+                # Skip non-directory entries
+                if not os.path.isdir(job_folder_path):
+                    continue
+                
+                file_names = sorted(os.listdir(job_folder_path))
+                for i in range(len(file_names) - 1):
+                    file_path1 = os.path.join(job_folder_path, file_names[i])
+                    file_path2 = os.path.join(job_folder_path, file_names[i + 1])
+
+                    if os.path.isfile(file_path1) and os.path.isfile(file_path2):
+                        differences = []
+                        with open(file_path1, 'r', encoding='utf-8') as file1, open(file_path2, 'r', encoding='utf-8') as file2:
+                            lines1 = file1.readlines()
+                            lines2 = file2.readlines()
+
+                            differ = difflib.Differ()
+                            diff = list(differ.compare(lines1, lines2))
+
+                            for j, line in enumerate(diff):
+                                # Check for differences (lines starting with '-' or '+')
+                                if line.startswith('-'):
+                                    differences.append(f"File #1: {os.path.basename(file_path1).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+                                elif line.startswith('+'):
+                                    differences.append(f"File #2: {os.path.basename(file_path2).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+
+                        if differences:
+                            nondeterminism = True
+                            print("Found nondeterminism! (check below for the differences found)")
+                            print(f"Filename #1: {file_path1} <-------> Filename #2: {file_path2}")
+                            for diff in differences:
+                                print(diff)
+                            print("\n\n\n")
+
+                            all_nd_results.append(differences)
+                    
+        except OSError as e:
+            print(f"Error creating or accessing directory {repo_folder}: {e}")
+        
+        except Exception as e:
+            print(f"Error: {e}")
+
+        if (not nondeterminism):
+            print("No nondeterminism detected!")
+            return "None reported"
+        else:
+            return all_nd_results

--- a/scripts/NDReaders/ValgrindReader.py
+++ b/scripts/NDReaders/ValgrindReader.py
@@ -1,0 +1,71 @@
+from AbstractReader import AbstractReader, T
+import os 
+import difflib
+
+class ValgrindReader(AbstractReader):
+    def __init__(self, repo_user, repo_name, output_dir, token):
+        self.output_dir = output_dir
+        self.repo_user = repo_user
+        self.repo_name = repo_name
+        self.results = {}
+        self.token = token 
+        self.import_file(self.output_dir, self.repo_name, "Run Valgrind", "<----------------------Start Valgrind Service---------------------->", self.token)
+    
+    def nondeterminism_analysis(self): 
+        output_dir = os.path.expanduser(self.output_dir)
+        repo_folder = os.path.join(output_dir, self.repo_name)
+        nondeterminism = False
+        all_nd_results = []
+
+        try:
+            os.makedirs(repo_folder, exist_ok=True)
+            # Iterate through all job folders in repo_folder
+            for job_folder in os.listdir(repo_folder):
+                job_folder_path = os.path.join(repo_folder, job_folder)
+
+                # Skip non-directory entries
+                if not os.path.isdir(job_folder_path):
+                    continue
+                
+                file_names = sorted(os.listdir(job_folder_path))
+                for i in range(len(file_names) - 1):
+                    file_path1 = os.path.join(job_folder_path, file_names[i])
+                    file_path2 = os.path.join(job_folder_path, file_names[i + 1])
+
+                    if os.path.isfile(file_path1) and os.path.isfile(file_path2):
+                        differences = []
+                        with open(file_path1, 'r', encoding='utf-8') as file1, open(file_path2, 'r', encoding='utf-8') as file2:
+                            lines1 = file1.readlines()
+                            lines2 = file2.readlines()
+
+                            differ = difflib.Differ()
+                            diff = list(differ.compare(lines1, lines2))
+
+                            for j, line in enumerate(diff):
+                                # Check for differences (lines starting with '-' or '+')
+                                if line.startswith('-'):
+                                    differences.append(f"File #1: {os.path.basename(file_path1).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+                                elif line.startswith('+'):
+                                    differences.append(f"File #2: {os.path.basename(file_path2).replace('.txt', '')} -----> Line {j+1}: {line.strip()}")
+
+                        if differences:
+                            nondeterminism = True
+                            print("Found nondeterminism! (check below for the differences found)")
+                            print(f"Filename #1: {file_path1} <-------> Filename #2: {file_path2}")
+                            for diff in differences:
+                                print(diff)
+                            print("\n\n\n")
+
+                            all_nd_results.append(differences)
+                    
+        except OSError as e:
+            print(f"Error creating or accessing directory {repo_folder}: {e}")
+        
+        except Exception as e:
+            print(f"Error: {e}")
+
+        if (not nondeterminism):
+            print("No nondeterminism detected!")
+            return "None reported"
+        else:
+            return all_nd_results


### PR DESCRIPTION
Although I have extracted all the logs, you can also do the same for future testing of other repositories with these NDReader Python scripts. As explained in the README.md, it allows you to...

(1) extract all GitHub workflow files named after the tool with the convention: "Run + toolkit name" 
(2) cleans-up unnecessary data from GitHub Actions and keeps only relevant parts for analysis purposes
(3) allows running of nondeterminism_analysis() based on file comparisons made against each logs of the same architecture according to the 10 branches conducted (the main branches are excluded from further analysis). 